### PR TITLE
Improve link validation in spec checker

### DIFF
--- a/tests/test_spec_checker.py
+++ b/tests/test_spec_checker.py
@@ -262,10 +262,27 @@ class TestLinksValidation(TestOGCRSpecChecker):
                 # Missing 'rel' field
             }
         ]
-        
+
         valid, errors = self.checker.validate_document(doc_with_links, "pdd")
         assert not valid
         assert any("missing required 'rel' field" in error for error in errors)
+
+    def test_links_field_not_array(self):
+        """Links field must be an array of link objects"""
+        doc_with_links = self.valid_pdd.copy()
+        # Provide a single link object instead of an array
+        doc_with_links["links"] = {
+            "rel": "self",
+            "href": "https://example.com"
+        }
+
+        valid, errors = self.checker.validate_document(doc_with_links, "pdd")
+        assert not valid
+        # Schema should complain about type mismatch, and our validator should
+        # add a clear error without emitting per-character object errors.
+        assert any("is not of type 'array'" in error for error in errors)
+        assert any("links must be an array" in error for error in errors)
+        assert not any("Link 0 must be an object" in error for error in errors)
 
 class TestBboxValidation(TestOGCRSpecChecker):
     """Test bbox validation"""

--- a/tools/spec_checker.py
+++ b/tools/spec_checker.py
@@ -175,17 +175,25 @@ class OGCRSpecChecker:
         
         links = document.get('links', [])
         if links:
+            # Links must be provided as an array. If the value is not a list,
+            # schema validation will already flag it, but without this check we
+            # would iterate over the invalid value and produce confusing
+            # per-character errors (e.g. "Link 0 must be an object").
+            if not isinstance(links, list):
+                errors.append("links must be an array of link objects")
+                return errors
+
             for i, link in enumerate(links):
                 if not isinstance(link, dict):
                     errors.append(f"Link {i} must be an object")
                     continue
-                    
+
                 # Check required fields
                 if 'rel' not in link:
                     errors.append(f"Link {i} missing required 'rel' field")
                 if 'href' not in link:
                     errors.append(f"Link {i} missing required 'href' field")
-                    
+
                 # Validate href is a valid URL
                 href = link.get('href')
                 if href:


### PR DESCRIPTION
## Summary
- ensure `links` field is a list before validating entries
- add regression test for non-array `links`

## Testing
- `pytest`