### PR TITLE
Add OpenAPI specification and validation tooling

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -1,0 +1,23 @@
+name: OpenAPI Validation
+
+on:
+  push:
+    paths:
+      - 'docs/openapi.yaml'
+      - 'tools/validate_openapi.py'
+      - '.github/workflows/openapi-validation.yml'
+  pull_request:
+    paths:
+      - 'docs/openapi.yaml'
+      - 'tools/validate_openapi.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r tools/requirements.txt
+      - run: python tools/validate_openapi.py

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,195 @@
+openapi: 3.0.3
+info:
+  title: OGCR API
+  description: OpenAPI specification for the OGCR API.
+  version: 0.1.0
+servers:
+  - url: https://api.ogcr.org/v1
+    description: Production server
+  - url: https://api-sandbox.carbon-registry.org/v1
+    description: Sandbox server
+security:
+  - OAuth2: []
+paths:
+  /projects:
+    post:
+      summary: Create a new project
+      operationId: createProject
+      security:
+        - OAuth2: [projects:write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Project'
+            example:
+              type: Feature
+              ogcr_version: '0.1.0'
+              profile: pdd
+              geometry:
+                type: Polygon
+                coordinates: [[[0,0],[1,0],[1,1],[0,1],[0,0]]]
+              properties:
+                name: Sample Project
+                project_type: afforestation
+      responses:
+        '201':
+          description: Project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+        '400':
+          $ref: '#/components/responses/Error'
+  /projects/{projectId}:
+    get:
+      summary: Retrieve a project by ID
+      operationId: getProject
+      security:
+        - OAuth2: [projects:read]
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          description: ID of the project to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Project details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+        '404':
+          $ref: '#/components/responses/Error'
+  /webhooks:
+    post:
+      summary: Register a webhook
+      operationId: createWebhook
+      security:
+        - OAuth2: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookConfig'
+            example:
+              url: https://your-app.com/webhooks/carbon-registry
+              events:
+                - project.approved
+                - credit.issued
+              secret: your-webhook-secret
+      responses:
+        '201':
+          description: Webhook registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Webhook'
+        '400':
+          $ref: '#/components/responses/Error'
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://api.ogcr.org/oauth/authorize
+          tokenUrl: https://api.ogcr.org/oauth/token
+          scopes:
+            projects:read: Read access to project data
+            projects:write: Create and update project data
+            projects:approve: Approve projects
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Project:
+      type: object
+      required:
+        - type
+        - ogcr_version
+        - profile
+        - geometry
+        - properties
+      properties:
+        type:
+          type: string
+          enum: [Feature]
+        id:
+          type: string
+        ogcr_version:
+          type: string
+        profile:
+          type: string
+          enum: [pdd]
+        geometry:
+          type: object
+          description: GeoJSON geometry object
+        properties:
+          type: object
+          required:
+            - name
+            - project_type
+          properties:
+            name:
+              type: string
+            project_type:
+              type: string
+    WebhookConfig:
+      type: object
+      required:
+        - url
+        - events
+      properties:
+        url:
+          type: string
+          format: uri
+        events:
+          type: array
+          items:
+            type: string
+        secret:
+          type: string
+    Webhook:
+      allOf:
+        - $ref: '#/components/schemas/WebhookConfig'
+        - type: object
+          properties:
+            id:
+              type: string
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+            timestamp:
+              type: string
+              format: date-time
+            request_id:
+              type: string
+  responses:
+    Error:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/run_tests.py
+++ b/run_tests.py
@@ -93,6 +93,12 @@ def main():
     total_count += 1
     if run_command("python -c 'import sys; sys.path.append(\"server\"); from app.main import app; print(\"FastAPI loaded successfully\")'", cwd=base_dir):
         success_count += 1
+
+    # Test 7: OpenAPI Specification Validation
+    print("\n7. Validating OpenAPI Specification...")
+    total_count += 1
+    if run_command("python tools/validate_openapi.py", cwd=base_dir):
+        success_count += 1
     
     # Summary
     print("\n" + "=" * 50)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
 pytest==7.4.3
 httpx==0.25.2
+openapi-spec-validator==0.7.1
+PyYAML==6.0.1
 

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -1,0 +1,12 @@
+"""Tests for OGCR OpenAPI specification"""
+
+from pathlib import Path
+import yaml
+from openapi_spec_validator import validate_spec
+
+
+def test_openapi_spec_valid() -> None:
+    spec_path = Path(__file__).resolve().parents[1] / "docs" / "openapi.yaml"
+    with spec_path.open("r", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+    validate_spec(spec)

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,5 @@
 jsonschema==4.20.0
 requests==2.31.0
+openapi-spec-validator==0.7.1
+PyYAML==6.0.1
 

--- a/tools/validate_openapi.py
+++ b/tools/validate_openapi.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+OGCR OpenAPI Specification Validator
+
+License: MIT
+Copyright (c) 2025 OGCR Consortium
+"""
+
+from pathlib import Path
+import yaml
+from openapi_spec_validator import validate_spec
+
+
+def main() -> None:
+    """Validate the OpenAPI specification file."""
+    spec_path = Path(__file__).resolve().parents[1] / "docs" / "openapi.yaml"
+    with spec_path.open("r", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+    validate_spec(spec)
+    print("OpenAPI specification is valid.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add initial OpenAPI 3.0 specification with project and webhook endpoints
- provide Python script and pytest to validate OpenAPI spec
- add GitHub workflow and test runner step for spec validation

## Testing
- `python tools/validate_openapi.py`
- `python -m pytest tests/test_openapi_spec.py -q`
- `python run_tests.py`
